### PR TITLE
More work to support Java 9+.

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -232,6 +232,9 @@ project 'JRuby Core' do
                           'org/jruby/runtime/**/*Test*.java' ],
           'additionalClasspathElements' => [ '${basedir}/src/test/ruby' ] )
 
+  plugin(:jar,
+         archive: {manifestEntries: {'Automatic-Module-Name' => 'org.jruby'}})
+
   build do
     default_goal 'package'
 
@@ -412,5 +415,13 @@ project 'JRuby Core' do
                      :id => 'pack core sources',
                      :phase => 'prepare-package' ) # Needs to run before the shade plugin
     end
+  end
+
+  profile 'java9' do
+    activation do
+      jdk '[9,)'
+    end
+
+    jar 'javax.annotation:javax.annotation-api:1.3.1', scope: 'compile'
   end
 end

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -597,6 +597,16 @@ DO NOT MODIFIY - GENERATED CODE
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.jruby</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
@@ -1247,6 +1257,20 @@ DO NOT MODIFIY - GENERATED CODE
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>java9</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+          <version>1.3.1</version>
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
* Automatic module name in manifest. Note that this does not help
  with cracking open core JDK modules, since the name does not
  exist at boot time.
* Include javax.annotation dependency when building on Java 9,
  since it has been removed from the JDK.